### PR TITLE
Fix compatibility with python 3.5

### DIFF
--- a/Utilities/Python/IxTclHal/IxTclHal.py
+++ b/Utilities/Python/IxTclHal/IxTclHal.py
@@ -5,7 +5,7 @@ import sys
 import os
 import io
 import re
-from . import IxTclHalError
+from .IxTclHalError import IxTclHalError
 #from IxTclHalError import IxTclHalError
 
 


### PR DESCRIPTION
properly import IxTclHalError so it will work with python 3.5